### PR TITLE
Configure version dependencies on ext_emconf.php & composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
-    "gridelementsteam/gridelements": "^9 || ^10 || ^11.0.0-dev"
+    "typo3/cms-core": "^10.4 || ^11.5",
+    "gridelementsteam/gridelements": "^10 || ^11.0.0"
   },
   "replace": {
     "typo3-ter/bootstrap-grids": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "issues": "https://github.com/laxap/bootstrap_grids/issues"
   },
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1",
+    "php": "^7.4 || ^8.0",
     "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
     "gridelementsteam/gridelements": "^9 || ^10 || ^11.0.0-dev"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
 	'constraints' => [
 		'depends' => [
 			'typo3' => '10.4.0-11.5.99',
-			'gridelements' => '9.0.0-11.99.99',
+			'gridelements' => '10.0.0-11.99.99',
 		],
 		'conflicts' => [],
         'suggests' => [],
@@ -29,5 +29,3 @@ $EM_CONF[$_EXTKEY] = [
         'psr-4' => ['Laxap\\BootstrapGrids\\' => 'Classes']
     ],
 ];
-
-?>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
 	'constraints' => [
 		'depends' => [
 			'typo3' => '10.4.0-11.5.99',
-			'gridelements' => '11.0.0-10.99.99',
+			'gridelements' => '9.0.0-11.99.99',
 		],
 		'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
- the ext_emconf.php version is now 9 to 11 to match definition of composer.json
- on composer.json ^8.0 || ^8.1 was replaced by ^8.0 as this already includes ^8.1